### PR TITLE
Use valid category value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Brian Carbonette
 maintainer=Brian Carbonette <bcarbonette@andium.com>
 sentence=AmazonDRS library for Arduino.
 paragraph=AmazonDRS library for Arduino.
-category=*
+category=Communication
 url=https://github.com/andium/AmazonDRS
 architectures=*


### PR DESCRIPTION
The previous `category` value causes the warning:
```
WARNING: Category '*' in library AmazonDRS is not valid. Setting to 'Uncategorized'
```
on every compilation when using any recent version of the Arduino IDE.

The list of valid category values is found here:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format